### PR TITLE
Fix weights in ABC randomizer test

### DIFF
--- a/src/__tests__/randomizer.test.js
+++ b/src/__tests__/randomizer.test.js
@@ -106,9 +106,9 @@ describe("Randomization algorithm for weighted variants:", () => {
     it("80/10/10 split", () => {
       const { isErrorRateLte1Precent } = calcABCVariantWeights(
         {
-          weightA: 40,
-          weightB: 40,
-          weightC: 20
+          weightA: 80,
+          weightB: 10,
+          weightC: 10
         },
         n
       );


### PR DESCRIPTION
## Summary
- fix ABC variant weights in the `80/10/10` test

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d51de04832489036bdec4389433